### PR TITLE
Fix fugitive detection

### DIFF
--- a/autoload/lining.vim
+++ b/autoload/lining.vim
@@ -232,7 +232,7 @@ else
 	endfunction
 endif
 
-if exists('*fugitive#detect') && exists('*fugitive#detect')
+if exists('*FugitiveDetect')
 	let s:git_item = {}
 	function! s:git_item.format(active, bufnum) abort
 		let head = fugitive#head()


### PR DESCRIPTION
Change search for deprecated function fugitive#detect and use
new public API function FugitiveDetect.

Original change in vim-fugitive in commot [cd7db1](
https://github.com/tpope/vim-fugitive/commit/cd7db1d57cc991b27d9c9ce6552faea3075ada61#diff-4c8459efc2f0fea43a9d26047a9e5e06R63289) (line 6328).

Signed-off-by: Andrés J. Díaz <ajdiaz@ajdiaz.me>