### PR TITLE
Fix more deprecated fugitive API

### DIFF
--- a/autoload/lining.vim
+++ b/autoload/lining.vim
@@ -232,7 +232,7 @@ else
 	endfunction
 endif
 
-if exists('*fugitive#detect') && exists('*fugitive#detect')
+if exists('*FugitiveDetect')
 	let s:git_item = {}
 	function! s:git_item.format(active, bufnum) abort
 		let head = fugitive#head()

--- a/autoload/lining.vim
+++ b/autoload/lining.vim
@@ -235,10 +235,10 @@ endif
 if exists('*FugitiveDetect')
 	let s:git_item = {}
 	function! s:git_item.format(active, bufnum) abort
-		let head = fugitive#head()
+		let head = FugitiveHead()
 		if empty(head) && !exists('b:git_dir')
-			call fugitive#detect(fnamemodify(bufname(a:bufnum), ':p:h'))
-			let head = fugitive#head()
+			call FugitiveDetect(fnamemodify(bufname(a:bufnum), ':p:h'))
+			let head = FugitiveHead()
 		endif
 		if empty(head)
 			return ''


### PR DESCRIPTION
This patch will fix other uses of deprecated fugitive API in the
form fugitive#xxx instead of new camelcase style.